### PR TITLE
Add Dockerfiles and default envs for Docker Compose

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json .
+RUN corepack enable && pnpm install
+COPY . .
+RUN pnpm build
+EXPOSE 3001
+CMD ["pnpm", "start"]

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json .
+RUN corepack enable && pnpm install
+COPY . .
+RUN pnpm build
+EXPOSE 3000
+CMD ["pnpm", "start"]

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json .
+RUN corepack enable && pnpm install
+COPY . .
+RUN pnpm build
+CMD ["pnpm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   postgres:
     image: postgres:15
@@ -22,8 +21,8 @@ services:
     build: ./apps/api
     command: pnpm start
     environment:
-      DATABASE_URL: ${DATABASE_URL}
-      REDIS_URL: ${REDIS_URL}
+      DATABASE_URL: postgres://postgres:postgres@postgres:5432/scraper
+      REDIS_URL: redis://redis:6379
     depends_on:
       - postgres
       - redis
@@ -41,8 +40,8 @@ services:
     build: ./apps/worker
     command: pnpm start
     environment:
-      DATABASE_URL: ${DATABASE_URL}
-      REDIS_URL: ${REDIS_URL}
+      DATABASE_URL: postgres://postgres:postgres@postgres:5432/scraper
+      REDIS_URL: redis://redis:6379
     depends_on:
       - postgres
       - redis


### PR DESCRIPTION
## Summary
- add Dockerfiles for API, web, and worker services
- set default Postgres and Redis URLs in docker-compose
- drop obsolete version field from docker-compose

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab82d4cc288333b54a448bc0899324