### PR TITLE
chore: enable NodeNext modules

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,15 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "commonjs",
+    "module": "nodenext",
     "moduleResolution": "node",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "types": ["node"],
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "lib": ["ES2020"]
   },
   "include": []
 }


### PR DESCRIPTION
## Summary
- use NodeNext module resolution
- target ES2020 lib in root tsconfig

## Testing
- `pnpm -r build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8d41c510833391ed807361cdb3a8