### PR TITLE
chore: add Node.js type definitions

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,17 +11,18 @@
     "test": "vitest"
   },
   "dependencies": {
-    "fastify": "^4.25.2",
     "@fastify/cors": "^8.3.0",
     "@fastify/helmet": "^12.0.0",
     "@trpc/server": "^10.45.0",
-    "zod": "^3.22.4",
+    "fastify": "^4.25.2",
     "pino": "^8.16.1",
-    "pino-pretty": "^10.2.0"
+    "pino-pretty": "^10.2.0",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
-    "typescript": "^5.4.0",
+    "@types/node": "^24.3.0",
     "tsx": "^4.7.1",
+    "typescript": "^5.4.0",
     "vitest": "^1.5.0"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,21 +10,22 @@
     "test": "vitest"
   },
   "dependencies": {
-    "next": "14.1.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
     "@tanstack/react-query": "^5.28.9",
     "@trpc/client": "^10.45.0",
     "@trpc/react-query": "^10.45.0",
+    "next": "14.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "typescript": "^5.4.0",
-    "vitest": "^1.5.0",
+    "@types/node": "^24.3.0",
+    "autoprefixer": "^10.4.16",
     "eslint": "^8.57.0",
     "eslint-config-next": "14.1.0",
-    "tailwindcss": "^3.4.1",
     "postcss": "^8.4.31",
-    "autoprefixer": "^10.4.16"
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.4.0",
+    "vitest": "^1.5.0"
   }
 }

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -16,8 +16,9 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "typescript": "^5.4.0",
+    "@types/node": "^24.3.0",
     "tsx": "^4.7.1",
+    "typescript": "^5.4.0",
     "vitest": "^1.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "scraper-platform",
   "private": true,
   "packageManager": "pnpm@10.5.2",
-  "workspaces": ["apps/*", "packages/*"],
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
   "scripts": {
     "build": "pnpm -r build",
     "dev": "pnpm -r dev",
@@ -10,7 +13,8 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "vitest": "^1.5.0",
-    "typescript": "^5.4.0"
+    "@types/node": "^24.3.0",
+    "typescript": "^5.4.0",
+    "vitest": "^1.5.0"
   }
 }


### PR DESCRIPTION
## Summary
- add `@types/node` to workspace and app packages

## Testing
- `pnpm -r build` *(fails: @scraper/worker build: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', or 'nodenext')*

------
https://chatgpt.com/codex/tasks/task_e_68ab8d44f5808333990684971275a642