### PR TITLE
fix: copy workspace manifests before pnpm install

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,8 +1,16 @@
 FROM node:18-alpine
 WORKDIR /app
-COPY package.json .
+
+# Copy workspace manifests to install dependencies with proper linking
+COPY pnpm-workspace.yaml package.json ./
+COPY packages/*/package.json packages/*/
+COPY apps/*/package.json apps/*/
 RUN corepack enable && pnpm install
+
+# Copy the full workspace and build the API package
 COPY . .
+WORKDIR /app/apps/api
 RUN pnpm build
+
 EXPOSE 3001
 CMD ["pnpm", "start"]

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,8 +1,16 @@
 FROM node:18-alpine
 WORKDIR /app
-COPY package.json .
+
+# Copy workspace manifests to install dependencies with proper linking
+COPY pnpm-workspace.yaml package.json ./
+COPY packages/*/package.json packages/*/
+COPY apps/*/package.json apps/*/
 RUN corepack enable && pnpm install
+
+# Copy the full workspace and build the web package
 COPY . .
+WORKDIR /app/apps/web
 RUN pnpm build
+
 EXPOSE 3000
 CMD ["pnpm", "start"]

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -1,7 +1,15 @@
 FROM node:18-alpine
 WORKDIR /app
-COPY package.json .
+
+# Copy workspace manifests to install dependencies with proper linking
+COPY pnpm-workspace.yaml package.json ./
+COPY packages/*/package.json packages/*/
+COPY apps/*/package.json apps/*/
 RUN corepack enable && pnpm install
+
+# Copy the full workspace and build the worker package
 COPY . .
+WORKDIR /app/apps/worker
 RUN pnpm build
+
 CMD ["pnpm", "start"]


### PR DESCRIPTION
## Summary
- copy pnpm-workspace.yaml and all package.json files before installing dependencies
- build each app from its subdirectory after copying full workspace

## Testing
- `pnpm test`
- ⚠️ `docker build -f apps/api/Dockerfile -t api-test .` (daemon unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68ab8feecf548333b73b631ed6207f52