### PR TITLE
Use repo root as Docker build context

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,8 +1,22 @@
 FROM node:18-alpine
 WORKDIR /app
-COPY package.json .
-RUN corepack enable && pnpm install
+
+# Copy root workspace files required for pnpm and TypeScript
+COPY package.json pnpm-workspace.yaml tsconfig.json ./
+COPY apps/*/package.json apps/*/
+COPY packages/*/package.json packages/*/
+
+# Install dependencies for the API package
+RUN corepack enable && pnpm install --filter ./apps/api...
+
+# Copy the rest of the repository
 COPY . .
-RUN pnpm build
+
+# Build the API
+RUN pnpm --filter ./apps/api... build
+
+# Runtime configuration
+WORKDIR /app/apps/api
 EXPOSE 3001
 CMD ["pnpm", "start"]
+

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,8 +1,22 @@
 FROM node:18-alpine
 WORKDIR /app
-COPY package.json .
-RUN corepack enable && pnpm install
+
+# Copy root workspace files required for pnpm and TypeScript
+COPY package.json pnpm-workspace.yaml tsconfig.json ./
+COPY apps/*/package.json apps/*/
+COPY packages/*/package.json packages/*/
+
+# Install dependencies for the web package
+RUN corepack enable && pnpm install --filter ./apps/web...
+
+# Copy the rest of the repository
 COPY . .
-RUN pnpm build
+
+# Build the web app
+RUN pnpm --filter ./apps/web... build
+
+# Runtime configuration
+WORKDIR /app/apps/web
 EXPOSE 3000
 CMD ["pnpm", "start"]
+

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -1,7 +1,21 @@
 FROM node:18-alpine
 WORKDIR /app
-COPY package.json .
-RUN corepack enable && pnpm install
+
+# Copy root workspace files required for pnpm and TypeScript
+COPY package.json pnpm-workspace.yaml tsconfig.json ./
+COPY apps/*/package.json apps/*/
+COPY packages/*/package.json packages/*/
+
+# Install dependencies for the worker package
+RUN corepack enable && pnpm install --filter ./apps/worker...
+
+# Copy the rest of the repository
 COPY . .
-RUN pnpm build
+
+# Build the worker
+RUN pnpm --filter ./apps/worker... build
+
+# Runtime configuration
+WORKDIR /app/apps/worker
 CMD ["pnpm", "start"]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,9 @@ services:
     volumes:
       - redisdata:/data
   api:
-    build: ./apps/api
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
     command: pnpm start
     environment:
       DATABASE_URL: postgres://postgres:postgres@postgres:5432/scraper
@@ -29,7 +31,9 @@ services:
     ports:
       - '3001:3001'
   web:
-    build: ./apps/web
+    build:
+      context: .
+      dockerfile: apps/web/Dockerfile
     environment:
       NEXT_PUBLIC_API_URL: http://localhost:3001
     depends_on:
@@ -37,7 +41,9 @@ services:
     ports:
       - '3000:3000'
   worker:
-    build: ./apps/worker
+    build:
+      context: .
+      dockerfile: apps/worker/Dockerfile
     command: pnpm start
     environment:
       DATABASE_URL: postgres://postgres:postgres@postgres:5432/scraper


### PR DESCRIPTION
## Summary
- reference root Dockerfiles in docker-compose
- copy root workspace config into package Dockerfiles before install

## Testing
- `pnpm test`
- `docker build -t test-api -f apps/api/Dockerfile .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8fec52d48333bbfe880dbb5b3c5b