### PR TITLE
chore: ensure docker images include root workspace

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -2,7 +2,7 @@ FROM node:18-alpine
 WORKDIR /app
 
 # Copy workspace manifests to install dependencies with proper linking
-COPY pnpm-workspace.yaml package.json ./
+COPY package.json pnpm-workspace.yaml tsconfig.json ./
 COPY packages/*/package.json packages/*/
 COPY apps/*/package.json apps/*/
 RUN corepack enable && pnpm install

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -2,7 +2,7 @@ FROM node:18-alpine
 WORKDIR /app
 
 # Copy workspace manifests to install dependencies with proper linking
-COPY pnpm-workspace.yaml package.json ./
+COPY package.json pnpm-workspace.yaml tsconfig.json ./
 COPY packages/*/package.json packages/*/
 COPY apps/*/package.json apps/*/
 RUN corepack enable && pnpm install

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -2,7 +2,7 @@ FROM node:18-alpine
 WORKDIR /app
 
 # Copy workspace manifests to install dependencies with proper linking
-COPY pnpm-workspace.yaml package.json ./
+COPY package.json pnpm-workspace.yaml tsconfig.json ./
 COPY packages/*/package.json packages/*/
 COPY apps/*/package.json apps/*/
 RUN corepack enable && pnpm install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,9 @@ services:
     volumes:
       - redisdata:/data
   api:
-    build: ./apps/api
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
     command: pnpm start
     environment:
       DATABASE_URL: postgres://postgres:postgres@postgres:5432/scraper
@@ -29,7 +31,9 @@ services:
     ports:
       - '3001:3001'
   web:
-    build: ./apps/web
+    build:
+      context: .
+      dockerfile: apps/web/Dockerfile
     environment:
       NEXT_PUBLIC_API_URL: http://localhost:3001
     depends_on:
@@ -37,7 +41,9 @@ services:
     ports:
       - '3000:3000'
   worker:
-    build: ./apps/worker
+    build:
+      context: .
+      dockerfile: apps/worker/Dockerfile
     command: pnpm start
     environment:
       DATABASE_URL: postgres://postgres:postgres@postgres:5432/scraper


### PR DESCRIPTION
## Summary
- ensure docker-compose uses explicit build contexts with per-service Dockerfiles
- copy root workspace manifests into service Dockerfiles before pnpm install

## Testing
- `pnpm install`
- `pnpm test`
- `docker build -t test-api -f apps/api/Dockerfile .` *(fails: command not found: docker)*
- `docker build -t test-web -f apps/web/Dockerfile .` *(fails: command not found: docker)*
- `docker build -t test-worker -f apps/worker/Dockerfile .` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9267371c833385c63a16421f1d1f