### PR TITLE
Ensure pnpm install after copying workspace

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -9,6 +9,7 @@ RUN corepack enable && pnpm install
 
 # Copy the full workspace and build the API package
 COPY . .
+RUN pnpm install --filter @scraper/api
 WORKDIR /app/apps/api
 RUN pnpm build
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -9,6 +9,7 @@ RUN corepack enable && pnpm install
 
 # Copy the full workspace and build the web package
 COPY . .
+RUN pnpm install --filter @scraper/web
 WORKDIR /app/apps/web
 RUN pnpm build
 

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -9,6 +9,7 @@ RUN corepack enable && pnpm install
 
 # Copy the full workspace and build the worker package
 COPY . .
+RUN pnpm install --filter @scraper/worker
 WORKDIR /app/apps/worker
 RUN pnpm build
 


### PR DESCRIPTION
## Summary
- restore workspace symlinks by running `pnpm install --filter` after copying the repo in web, api, and worker Dockerfiles

## Testing
- `pnpm test`
- `pnpm lint` *(fails: prompts for ESLint configuration in apps/web)*

------
https://chatgpt.com/codex/tasks/task_e_68ab947bf8f4833385f78ef916910894